### PR TITLE
Support for enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ writer.write 'timeline', {
 *Note:*  bison-types uses [clever-buffer](https://github.com/TabDigital/clever-buffer) under the hood for all buffer manipulation.
 
 
-## Provided simple types
+## Provided types
+
+The following types can be declared as a string, for example: `{timestamp: 'uint16'}`.
 
 * `uint8`  - unsigned 8 bit integer
 * `uint16` - unsigned 16 bit integer
@@ -80,12 +82,29 @@ writer.write 'timeline', {
 * `bool`   - boolean (stored as 8 bit integer)
 * `skip`   - will skip specified bytes
 
+The is also an `enumeration` type, which can be used to represent enums from arrays of objects:
+
+```coffee
+# will store the index in the array
+level = bison.enumeration 'uint8', ['admin', 'reader', 'writer']
+
+# will store the value in the object
+level = bison.enumeration 'uint16',
+  'admin': 0xb8a3
+  'reader': 0xb90a
+  'writer': 0xf23c
+
+bison.preCompile
+  'user': [
+    {id: 'uint8'}
+    {level: level}
+  ]
+```
 
 ## Creating your own custom types
 
-*NOTE:* All examples are written in coffeescript
-
 There are 2 different ways that you can define a custom type
+
 ### By mapping it to another type
 
 ```coffee
@@ -106,9 +125,10 @@ would create an object like
 ```
 
 ### By explicitly creating a _read function
+
 We expose the underlying [clever-buffer](https://github.com/TabDigital/clever-buffer) as @buffer.
 
-You can call any of it's methods
+You can call any of its methods
 
 ```coffee
   types = bison.preCompile

--- a/src/enum.coffee
+++ b/src/enum.coffee
@@ -1,0 +1,18 @@
+_    = require 'lodash'
+util = require 'util'
+
+module.exports = (type, lookup) ->
+
+  if util.isArray lookup
+    _read: ->
+      index = @read type
+      lookup[index]
+    _write: (value) ->
+      @write type, lookup.indexOf(value)
+
+  else
+    _read: ->
+      value = @read type
+      _.findKey lookup, (val) -> val == value
+    _write: (key) ->
+      @write type, lookup[key]

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 require("coffee-script");
-exports.Reader     = require("./reader");
-exports.Writer     = require("./writer");
-exports.preCompile = require("./preCompile");
+exports.Reader       = require("./reader");
+exports.Writer       = require("./writer");
+exports.preCompile   = require("./preCompile");
+exports.enumeration  = require("./enum");

--- a/test/enum.spec.coffee
+++ b/test/enum.spec.coffee
@@ -1,0 +1,61 @@
+should       = require 'should'
+enumeration  = require "#{SRC}/enum"
+preCompile   = require "#{SRC}/preCompile"
+Reader       = require "#{SRC}/reader"
+Writer       = require "#{SRC}/writer"
+
+describe 'Bison enum', ->
+
+  describe 'arrays', ->
+
+    levels = [ 'admin', 'reader', 'writer' ]
+
+    types = preCompile
+      'level': enumeration('uint8', levels)
+      'level16': enumeration('uint16', levels)
+
+    it 'should encode the enum as its index', ->
+      writer = new Writer emptyBuffer(), types
+      writer.write 'level', 'reader'
+      writer.rawBuffer().should.eql new Buffer [ 0x01, 0x00, 0x00, 0x00 ]
+
+    it 'should decode the index as the enum value', ->
+      buf = new Buffer [ 0x02, 0x00, 0x00, 0x00 ]
+      reader = new Reader buf, types
+      reader.read('level').should.eql 'writer'
+
+    it 'can encode to any given type', ->
+      writer = new Writer emptyBuffer(), types, {bigEndian: true}
+      writer.write 'level16', 'reader'
+      writer.rawBuffer().should.eql new Buffer [ 0x00, 0x01, 0x00, 0x00 ]
+
+    it 'can decode from any given type', ->
+      buf = new Buffer [ 0x00, 0x02, 0x00, 0x00 ]
+      reader = new Reader buf, types, {bigEndian: true}
+      reader.read('level16').should.eql 'writer'
+
+  describe 'objects', ->
+
+    levels =
+      'admin': 0xaa11
+      'reader': 0xbb22
+      'writer': 0xcc33
+
+    types = preCompile
+      'level': enumeration('uint16', levels)
+
+    it 'should encode the enum as the object value', ->
+      writer = new Writer emptyBuffer(), types
+      writer.write 'level', 'reader'
+      writer.rawBuffer().should.eql new Buffer [ 0x22, 0xbb, 0x00, 0x00 ]
+
+    it 'should decode the index as the object key', ->
+      buf = new Buffer [ 0x33, 0xcc, 0x00, 0x00 ]
+      reader = new Reader buf, types
+      reader.read('level').should.eql 'writer'
+
+
+emptyBuffer = ->
+  buf = new Buffer 4
+  buf.fill 0
+  buf


### PR DESCRIPTION
Can use an enum array, which stores the index:

``` coffee
level = bison.enumeration 'uint8', [ 'admin', 'reader', 'writer' ]

types = bison.preCompile
  'level': level
```

or an enum object, which stores the given value:

``` coffee
level = bison.enumeration 'uint16',
  admin: 0x7c98
  reader: 0xb12d
  writer: 0x9f3a

types = bison.preCompile
  'level': level
```
