### PR TITLE
Prevents value for 'skip' fields

### DIFF
--- a/src/types.coffee
+++ b/src/types.coffee
@@ -40,7 +40,9 @@ module.exports =
     _write: (val) -> @buffer.writeUInt8(if val then 1 else 0)
 
   'skip'  :
-    _read : (len) -> @buffer.skip len
+    _read : (len) ->
+      @buffer.skip len
+      return
     _write: (val, len) -> @buffer.skip len
 
   'bytes' :

--- a/test/reader.spec.coffee
+++ b/test/reader.spec.coffee
@@ -137,7 +137,9 @@ describe 'Bison Reader', ->
     ]
 
     reader = new Reader buf, types
-    reader.read('custom').c.should.eql 4
+    res = reader.read('custom')
+    res.c.should.eql 4
+    (typeof res.b).should.eql 'undefined'
 
   it 'should be able to read bytes', ->
     buf = new Buffer [ 0x01, 0x02, 0x03, 0x04 ]


### PR DESCRIPTION
The issue comes from the same type of code in clever-buffer, which is fixed by https://github.com/TabDigital/clever-buffer/pull/5

The added test doesn't pass without explicitly returning nothing here
Perhaps remove the return change when this library is updated to use the updated clever-buffer, as the new tests will pass without the change.