### PR TITLE
Move to latest version of clever-buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "lodash": "~2.4.1",
     "coffee-script": "^1.7.1",
-    "clever-buffer": "^1.1.0",
+    "clever-buffer": "2.0.0",
     "big.js": "~2.5.1"
   },
   "devDependencies": {

--- a/test/reader.spec.coffee
+++ b/test/reader.spec.coffee
@@ -137,7 +137,9 @@ describe 'Bison Reader', ->
     ]
 
     reader = new Reader buf, types
-    reader.read('custom').c.should.eql 4
+    res = reader.read('custom')
+    res.c.should.eql 4
+    (typeof res.b).should.eql 'undefined'
 
   it 'should be able to read bytes', ->
     buf = new Buffer [ 0x01, 0x02, 0x03, 0x04 ]


### PR DESCRIPTION
@TabDigital/ping-api 

Move to latest version of `clever-buffer` (2.0.0) which:
* Uses the latest version of `ref`
* Does not return a value when using `skip`