### PR TITLE
Update all dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
     "url": "https://github.com/TabDigital/bison-types/issues"
   },
   "dependencies": {
-    "big.js": "~2.5.1",
-    "clever-buffer": "^2.0.0",
-    "lodash": "^2.4.1"
+    "big.js": "~3.1.3",
+    "clever-buffer": "^2.0.3",
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
-    "coffee-script": "^1.7.1",
-    "mocha": "~1.20.1",
-    "should": "~4.0.4",
-    "sinon": "~1.10.3",
-    "cli-table": "~0.3.0"
+    "coffee-script": "^1.10.0",
+    "mocha": "~2.5.1",
+    "should": "~8.4.0",
+    "sinon": "~1.17.4",
+    "cli-table": "~0.3.1"
   }
 }

--- a/test/preCompile.spec.coffee
+++ b/test/preCompile.spec.coffee
@@ -2,6 +2,7 @@ commonTypes = require "#{SRC}/types"
 preCompile  = require "#{SRC}/preCompile"
 
 describe 'PreCompile', ->
+
   it 'should pre compile the common types', ->
     typeSet = preCompile {}
     typeSet.definitions['uint8'].should.eql
@@ -41,7 +42,7 @@ describe 'PreCompile', ->
       isArray: false
       isFunction: true
       isOverride: false
-      parameter: 2
+      parameter: '2'
       arraySize: undefined
       name: 'uint8'
       value: commonTypes['uint8']
@@ -63,7 +64,7 @@ describe 'PreCompile', ->
       isFunction: false
       isOverride: false
       parameter: undefined
-      arraySize: 2
+      arraySize: '2'
       name: 'uint8'
       value: commonTypes['uint8']
       overrideValue: undefined
@@ -87,7 +88,7 @@ describe 'PreCompile', ->
       arraySize: undefined
       name: 'uint8'
       value: commonTypes['uint8']
-      overrideValue: 2
+      overrideValue: '2'
     typeSet.definitions['my-type'].should.eql
       isArray: false
       isFunction: false


### PR DESCRIPTION
Just keeping up to date.

This picked up a weird behaviour in the existing tests, because `should@4.0.4`considered that `2.should.eql('2')`. This means the tests didn't reflect reality, but it's fixed in `should@8.4.0`.