### PR TITLE
Adding latin1 type

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The following types can be declared as a string, for example: `{timestamp: 'uint
 * `int32`  - signed 32 bit integer
 * `int64`  - signed 64 bit integer
 * `utf-8`  - utf-8 encoded string
+* `latin1` - latin1 encoded string
 * `bool`   - boolean (stored as 8 bit integer)
 * `skip`   - will skip specified bytes
 
@@ -184,6 +185,34 @@ You can also pass in options, look at [clever-buffer](https://github.com/TabDigi
     myType = reader.read('my-type') # myType = { a: 'HELLO' }
 ```
 
+### Reading a string with latin1 encoding
+```coffee
+    bison = require 'bison-types'
+
+    buf = new Buffer [0x48, 0xC9, 0x4C, 0x4C, 0x4F]
+    types = bison.preCompile
+      my-type: [
+        a: 'latin1(5)'
+      ]
+    options = {bigEndian: false}
+    reader = new bison.Reader buf, types, options
+    myType = reader.read('my-type') # myType = { a: 'HELLO' }
+```
+
+### Reading a multi-byte string
+```coffee
+    bison = require 'bison-types'
+
+    buf = new Buffer [0x48, 0xC3, 0x89, 0x4C, 0x4C, 0x4F]
+    types = bison.preCompile
+      my-type: [
+        a: 'utf-8(6)'
+      ]
+    options = {bigEndian: false}
+    reader = new bison.Reader buf, types, options
+    myType = reader.read('my-type') # myType = { a: 'HÉLLO' }
+```
+
 ### Complex types
 The power of bison-types is evident as you define more complex types
 ```coffee
@@ -281,6 +310,21 @@ You can also pass in options, look at [clever-buffer](https://github.com/TabDigi
     # buf will equal [0x48, 0x45, 0x4C, 0x4C, 0x4F]
 ```
 
+### Writing a string with latin1 encoding
+```coffee
+    bison = require 'bison-types'
+
+    buf = new Buffer 5
+    types = bison.preCompile
+      my-type: [
+        a: 'latin1'
+      ]
+    options = {bigEndian: false}
+    writer = new bison.Writer buf, types, options
+    writer.write 'my-type', { a: 'HÉLLO' }
+    # buf will equal [0x48, 0xC9, 0x4C, 0x4C, 0x4F]
+```
+
 ### Only writing a certain length of string
 ```coffee
     bison = require 'bison-types'
@@ -294,6 +338,21 @@ You can also pass in options, look at [clever-buffer](https://github.com/TabDigi
     writer = new bison.Writer buf, types, options
     writer.write 'my-type', { a: 'HELLOWORLD' }
     # buf will equal [0x48, 0x45, 0x4C, 0x4C, 0x4F, 0x00, 0x00, 0x00, 0x00, 0x00]
+```
+
+### Writing a multi-byte string
+```coffee
+    bison = require 'bison-types'
+
+    buf = new Buffer 6
+    types = bison.preCompile
+      my-type: [
+        a: 'utf-8'
+      ]
+    options = {bigEndian: false}
+    writer = new bison.Writer buf, types, options
+    writer.write 'my-type', { a: 'HÉLLO' }
+    # buf will equal [0x48, 0xC3, 0x89, 0x4C, 0x4C, 0x4F]
 ```
 
 ### Complex types

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "big.js": "~3.1.3",
-    "clever-buffer": "^2.0.3",
+    "clever-buffer": "^2.0.5",
     "lodash": "^4.13.1"
   },
   "devDependencies": {

--- a/src/types.coffee
+++ b/src/types.coffee
@@ -31,6 +31,10 @@ module.exports =
     _read : -> @buffer.getInt64()
     _write: (val) -> @buffer.writeInt64(val)
 
+  'latin1' :
+    _read : (length) -> @buffer.getString { length: length, encoding: 'binary' }
+    _write: (val) -> @buffer.writeString val, { encoding: 'binary' }
+
   'utf-8' :
     _read : (length) -> @buffer.getString {length}
     _write: (val, length) -> @buffer.writeString val, {length}

--- a/test/reader.spec.coffee
+++ b/test/reader.spec.coffee
@@ -104,6 +104,11 @@ describe 'Bison Reader', ->
     reader = new Reader buf
     reader.read('utf-8', 5).should.eql 'HELLO'
 
+  it 'should read multi-byte string', ->
+    buf =  new Buffer [0x48, 0xC3, 0x89, 0x4C, 0x4C, 0x4F]
+    reader = new Reader buf
+    reader.read('utf-8', 6).should.eql 'HÉLLO'
+
   it 'should read string with latin1 encoding', ->
     buf =  new Buffer [0x48, 0xC9, 0x4C, 0x4C, 0x4F]
     reader = new Reader buf

--- a/test/reader.spec.coffee
+++ b/test/reader.spec.coffee
@@ -104,6 +104,11 @@ describe 'Bison Reader', ->
     reader = new Reader buf
     reader.read('utf-8', 5).should.eql 'HELLO'
 
+  it 'should read string with latin1 encoding', ->
+    buf =  new Buffer [0x48, 0xC9, 0x4C, 0x4C, 0x4F]
+    reader = new Reader buf
+    reader.read('latin1', 5).should.eql 'HÉLLO'
+
   it 'should be able to define a simple type', ->
     buf = new Buffer [ 0x01 ]
     reader = new Reader buf, preCompile {'my-simple-type': 'uint8'}

--- a/test/writer.spec.coffee
+++ b/test/writer.spec.coffee
@@ -124,6 +124,12 @@ describe 'Bison Writer', ->
     writer.write 'utf-8', 'HELLO'
     writer.rawBuffer().should.eql new Buffer [0x48, 0x45, 0x4C, 0x4C, 0x4F]
 
+  it 'should write multi-byte string', ->
+    buf =  new Buffer 6
+    writer = new Writer buf
+    writer.write 'utf-8', 'HÉLLO'
+    writer.rawBuffer().should.eql new Buffer [0x48, 0xC3, 0x89, 0x4C, 0x4C, 0x4F]
+
   it 'should write string with latin1 encoding', ->
     buf =  new Buffer 5
     writer = new Writer buf

--- a/test/writer.spec.coffee
+++ b/test/writer.spec.coffee
@@ -124,6 +124,12 @@ describe 'Bison Writer', ->
     writer.write 'utf-8', 'HELLO'
     writer.rawBuffer().should.eql new Buffer [0x48, 0x45, 0x4C, 0x4C, 0x4F]
 
+  it 'should write string with latin1 encoding', ->
+    buf =  new Buffer 5
+    writer = new Writer buf
+    writer.write 'latin1', 'HÉLLO'
+    writer.rawBuffer().should.eql new Buffer [0x48, 0xC9, 0x4C, 0x4C, 0x4F]
+
   it 'should be able to write bytes', ->
     buf =  new Buffer 5
     writer = new Writer buf


### PR DESCRIPTION
cc @nguyenchr @rprieto

re https://github.com/TabDigital/bison-types/issues/16

* adding string type with latin1 encoding (single byte)
* update utf8 to use the correct length with multi-byte strings

