### PR TITLE
fix/pad-short-utf8[n]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bison-types",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Convert between json and binary",
   "main": "target/index.js",
   "scripts": {

--- a/src/types.coffee
+++ b/src/types.coffee
@@ -39,7 +39,7 @@ module.exports =
     _read : (length) -> @buffer.getString {length}
     _write: (val, length) ->
       count = @buffer.writeString val, {length}
-      @buffer.skip length - count if count < length
+      count += @buffer.writeUInt8 0x00 while count < length
       length
 
   'bool' :

--- a/src/types.coffee
+++ b/src/types.coffee
@@ -37,7 +37,10 @@ module.exports =
 
   'utf-8' :
     _read : (length) -> @buffer.getString {length}
-    _write: (val, length) -> @buffer.writeString val, {length}
+    _write: (val, length) ->
+      count = @buffer.writeString val, {length}
+      @buffer.skip length - count if count < length
+      length
 
   'bool' :
     _read : -> if @buffer.getUInt8() then true else false

--- a/test/writer.spec.coffee
+++ b/test/writer.spec.coffee
@@ -248,6 +248,19 @@ describe 'Bison Writer', ->
     writer.write 'custom', { a: 'HELLOWORLD' }
     writer.rawBuffer().should.eql new Buffer [0x48, 0x45, 0x4C, 0x4C, 0x4F, 0x00, 0x00, 0x00, 0x00, 0x00] #Only writes hello
 
+  it 'should be able to write an undersized string of a certain length', ->
+    buf = new Buffer 12
+    buf.fill 0xff
+    types = preCompile
+      custom: [
+        {a: 'utf-8(6)'}
+        {b: 'utf-8(6)'}
+      ]
+
+    writer = new Writer buf, types
+    writer.write 'custom', { a: 'HELLO', b: 'WORLD' }
+    writer.rawBuffer().should.eql new Buffer [0x48, 0x45, 0x4C, 0x4C, 0x4F, 0x00, 0x57, 0x4F, 0x52, 0x4C, 0x44, 0x00] # pads end with NUL
+
   it 'should be able to specify a parameter', ->
     buf = new Buffer 2
     types = preCompile


### PR DESCRIPTION
This is a fix for encoding fixed length utf-8 strings where the string is shorter than the given length.

In cdef-messages we have this structure for 'Combined Pay Redeem - 0D18h'
```
'batch-bet': [
    {length: 'skip(4)'}
    {function_code: 'uint16'}
    {transaction_number: 'uint8'}
    {bet_sys_flags: 'uint8'}
    {bet_app_flags: 'uint8'}
    {serial_number: 'uint64'}
    {voucher_password: 'utf-8(4)'}
    {current_session_balance: 'cdef-money'}
  ]
```

If we encode this structure with `voucher_password: "12"` (two bytes shorter than required), then the offsets for the remaining fields will be off by two. Worse; a decoder has no way of knowing that this has occurred.

Seeing as oversized strings are truncated to ensure the fields have the correct offsets, it would make sense for undersized strings to be NUL padded to ensure correct offsets as well.

With this change `voucher_password` will be padded to "12\0\0", so that the remainder of the structure can be decoded correctly.