### PR TITLE
bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bison-types",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Convert between json and binary",
   "main": "target/index.js",
   "scripts": {

--- a/src/types.coffee
+++ b/src/types.coffee
@@ -39,7 +39,9 @@ module.exports =
     _read : (length) -> @buffer.getString {length}
     _write: (val, length) ->
       count = @buffer.writeString val, {length}
-      count += @buffer.writeUInt8 0x00 while count < length
+      while count < length
+        @buffer.writeUInt8 0x00
+        count++
       length
 
   'bool' :

--- a/test/writer.spec.coffee
+++ b/test/writer.spec.coffee
@@ -249,17 +249,17 @@ describe 'Bison Writer', ->
     writer.rawBuffer().should.eql new Buffer [0x48, 0x45, 0x4C, 0x4C, 0x4F, 0x00, 0x00, 0x00, 0x00, 0x00] #Only writes hello
 
   it 'should be able to write an undersized string of a certain length', ->
-    buf = new Buffer 12
+    buf = new Buffer 14
     buf.fill 0xff
     types = preCompile
       custom: [
         {a: 'utf-8(6)'}
-        {b: 'utf-8(6)'}
+        {b: 'utf-8(7)'}
       ]
 
     writer = new Writer buf, types
     writer.write 'custom', { a: 'HELLO', b: 'WORLD' }
-    writer.rawBuffer().should.eql new Buffer [0x48, 0x45, 0x4C, 0x4C, 0x4F, 0x00, 0x57, 0x4F, 0x52, 0x4C, 0x44, 0x00] # pads end with NUL
+    writer.rawBuffer().should.eql new Buffer [0x48, 0x45, 0x4C, 0x4C, 0x4F, 0x00, 0x57, 0x4F, 0x52, 0x4C, 0x44, 0x00, 0x00, 0xff] # pads end with NUL
 
   it 'should be able to specify a parameter', ->
     buf = new Buffer 2


### PR DESCRIPTION
Padding a fixed width string has a bug in it.

Consider when we pad a string out to the given length:
```coffeescript
count += @buffer.writeUInt8 0x00 while count < length
```

I assumed that `@buffer.writeUInt8` would return the number of bytes written (1 byte each time). However, it actually returns the number written, plus the current offset see: https://nodejs.org/api/buffer.html#buffer_buf_writeuint8_value_offset_noassert.

So what we really want is this:
```coffeescript
while count < length
    @buffer.writeUInt8 0x00
    count++
```

I've also modified the unit test to also check this edge case.
